### PR TITLE
restEndpoint mapped to localhost instead of *

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -183,7 +183,7 @@ func lndMain() error {
 	sCreds := credentials.NewTLS(tlsConf)
 	serverOpts := []grpc.ServerOption{grpc.Creds(sCreds)}
 	grpcEndpoint := fmt.Sprintf("localhost:%d", loadedConfig.RPCPort)
-	restEndpoint := fmt.Sprintf(":%d", loadedConfig.RESTPort)
+	restEndpoint := fmt.Sprintf("localhost:%d", loadedConfig.RESTPort)
 	cCreds, err := credentials.NewClientTLSFromFile(cfg.TLSCertPath,
 		"")
 	if err != nil {


### PR DESCRIPTION
I don't see a reason for restEndpoint to be mapped to *, while grpcEndpoint is only mapped to localhost. I assume it is probably safer to also map restEndpoint to localhost, to avoid security issues with nodes not protected by a firewall.